### PR TITLE
change default principal type

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ No modules.
 | <a name="input_scope"></a> [scope](#input\_scope) | The scope at which the Role Assignment applies to, such as /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333,<br>    /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup,<br>    or /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM,<br>    or /providers/Microsoft.Management/managementGroups/myMG. Changing this forces a new resource to be created. | `string` | n/a | yes |
 | <a name="input_role_definition_name"></a> [role\_definition\_name](#input\_role\_definition\_name) | (Optional) Name of the Role Definition. Changing this forces a new resource to be created. Example: Reader | `string` | `null` | no |
 | <a name="input_principal_id"></a> [principal\_id](#input\_principal\_id) | The ID of the Principal (User, Group or Service Principal) to assign the Role Definition to. Changing this forces a new resource to be created. | `string` | n/a | yes |
-| <a name="input_principal_type"></a> [principal\_type](#input\_principal\_type) | (Optional) The type of Principal to assign the Role Definition to. Changing this forces a new resource to be created.<br>    Possible values are User, Group, ServicePrincipal, and Application. Default is User. | `string` | `"User"` | no |
+| <a name="input_principal_type"></a> [principal\_type](#input\_principal\_type) | (Optional) The type of Principal to assign the Role Definition to. Changing this forces a new resource to be created.<br>    Possible values are User, Group, ServicePrincipal, and Application. Default is ServicePrincipal. | `string` | `"ServicePrincipal"` | no |
 
 ## Outputs
 

--- a/variables.tf
+++ b/variables.tf
@@ -40,7 +40,7 @@ variable "principal_id" {
 variable "principal_type" {
   description = <<EOT
     (Optional) The type of Principal to assign the Role Definition to. Changing this forces a new resource to be created.
-    Possible values are User, Group, ServicePrincipal, and Application. Default is User.
+    Possible values are User, Group, ServicePrincipal, and Application. Default is ServicePrincipal.
   EOT
   type        = string
   default     = "ServicePrincipal"

--- a/variables.tf
+++ b/variables.tf
@@ -43,5 +43,5 @@ variable "principal_type" {
     Possible values are User, Group, ServicePrincipal, and Application. Default is User.
   EOT
   type        = string
-  default     = "User"
+  default     = "ServicePrincipal"
 }


### PR DESCRIPTION
Before #7 was merged, the module created role assignments with principal type `ServicePrincipal` by default

Changing the default to `User` has broken some reference modules which assign roles to service principals

This changes the default to `ServicePrincipal` to match the previous behavior